### PR TITLE
refactor crm login and browser closing into helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,18 @@ describe('[new-topic] tests', function() {
 *Setting `this.timeout(0)` disables Mocha from timing out for all tests under that `describe()`. Set it to another value (in milliseconds), if you know the CRM shouldn't take longer than that amount of time for any operation.
 
 In your topic-specific test, there generally is no need to set up the browser and login to CRM.
-This should already be done through the `./test/setup-signin.js` file.
+This should already be done through the `./test/setup.js` file.
 
 You'll be able to access and interact with the page object through the `page` variable.
 
 For an example, see `./test/login/login-test.js`
+
+If in your tests you need to spin up the browser again, login to CRM, or close the browser, you can make use of the test helpers in `./test/helpers/setup.js` and `./test/helpers/teardown.js`.
+
+At the top of your test file, import them like so:
+
+```
+const setupHelpers = require('../path/to/helpers/setup');
+// or 
+const teardownHelpers = require('../path/to/helpers/teardown');
+```

--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -1,0 +1,15 @@
+require('dotenv').config();
+
+exports.loginToCrm = async function(page) {
+  await page.goto(process.env.ZAP_DOMAIN);
+  await page.type('input', process.env.ZAP_USERNAME);
+  await page.click('[value="Next"]');
+  await page.waitForSelector('#passwordInput');
+  await page.type('#passwordInput', process.env.ZAP_PASS);
+  await page.click('#submitButton');
+  await page.waitForSelector('#idBtn_Back');
+  // Select "No" when asked "Stay Signed In?"
+  await page.click('#idBtn_Back');
+  // wait for Dashboard to appear
+  await page.waitForSelector('#marsIFrame');
+}

--- a/test/helpers/teardown.js
+++ b/test/helpers/teardown.js
@@ -1,0 +1,7 @@
+exports.logoutOfCRM = async function(page) {
+  // logout code here
+}
+
+exports.closeBrowser = async function(browser) {
+  await browser.close();
+}

--- a/test/login/logged-in-test.js
+++ b/test/login/logged-in-test.js
@@ -1,6 +1,6 @@
 const chai = require('chai');
 
-describe('Login tests', function() {
+describe('Logged in tests', function() {
   // Setting this.timeout(0) disables Mocha from timing out for all
   // tests under that describe().
   // Set it to another value (in milliseconds), if you know the CRM

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,8 +1,8 @@
 # SETUP 
---file ./test/setup-signin.js
+--file ./test/setup.js
 
 # AUTOMATED TEST CASES
---file ./test/login/login-test.js
+--file ./test/login/logged-in-test.js
 --file ./test/project/create-project-test.js
 
 # TEARDOWN

--- a/test/setup.js
+++ b/test/setup.js
@@ -4,7 +4,7 @@
 // for use across all test files under `./tests`.
 // It also signs into CRM based on credentials provided in `.env`. 
 const Puppeteer = require('puppeteer');
-require('dotenv').config();
+const setupHelpers = require('./helpers/setup');
 
 browser = null;
 page = null;
@@ -20,15 +20,8 @@ setTimeout(async function() {
   });
 
   page = await browser.newPage();
-  await page.goto(process.env.ZAP_DOMAIN);
-  await page.type('input', process.env.ZAP_USERNAME);
-  await page.click('[value="Next"]');
-  await page.waitForSelector('#passwordInput');
-  await page.type('#passwordInput', process.env.ZAP_PASS);
-  await page.click('#submitButton');
-  await page.waitForSelector('#idBtn_Back');
-  await page.click('#idBtn_Back');
-  await page.waitForSelector('#marsIFrame');
+  // `await` here is critical, because the helper has async processes
+  await setupHelpers.loginToCrm(page);
 
   run();
 }, 0);

--- a/test/teardown.js
+++ b/test/teardown.js
@@ -1,9 +1,10 @@
+const teardownHelpers = require('./helpers/teardown');
+
 // This file performs teardown for all tests.
 // It should be called last, as specified in `mocha.opts`
-// Primarily it closes the browser window.
 describe('Teardown', function() {
   this.timeout(0);
   it('closes the browser', async function() {
-    await browser.close();
+    await teardownHelpers.closeBrowser(browser);
   });
 });


### PR DESCRIPTION
A small PR to highlight how CRM login and browser close functionality are now sitting in helpers. In the future there may be many helpers for login/logout, startup/exit that can be conveniently called from within test cases.  